### PR TITLE
feat: add gated contrastive training

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -46,7 +46,8 @@ def evaluate(model, loader):
     with torch.no_grad():
         for batch in tqdm(loader):
             _, pred = model.ner_forward(batch)
-            true_labels += [[constants.ID_TO_LABEL[token.label] for token in pair.sentence] for pair in batch]
+            pairs = batch["pairs"] if isinstance(batch, dict) else batch
+            true_labels += [[constants.ID_TO_LABEL[token.label] for token in pair.sentence] for pair in pairs]
             pred_labels += pred
 
     f1 = f1_score(true_labels, pred_labels, mode='strict', scheme=IOB2)


### PR DESCRIPTION
## Summary
- build custom collate_fn to create negative image pairs for contrastive learning
- extend model with gating head, projection layers and ITM/InfoNCE losses
- update training pipeline and evaluation to use new batch format

## Testing
- `python -m py_compile data/dataset.py main.py utils.py model/model.py`


------
https://chatgpt.com/codex/tasks/task_e_689b3c6ffe608325b4dcf79a63b39fbf