### PR TITLE
feat: 支持模型保存、周期存储与加载测试

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,8 @@ to [this path](resources/models/embeddings).
 python main.py --stacked --rnn --crf --dataset [dataset_id] --cuda [gpu_id]
 # RpBERT-BiLSTM-CRF
 python main.py --stacked --rnn --crf --encoder_v resnet101 --aux --gate --dataset twitter2017 --cuda [gpu_id]
+# 保存最佳模型到 ./ckpt 并每3轮保存一次
+python main.py --encoder_v resnet101 --gate --save_interval 3
+# 直接加载已有模型评估测试集
+python main.py --load_model ckpt/best_model.pt
 ```


### PR DESCRIPTION
## Summary
- 在最佳验证分数时保存模型到`./ckpt`，并可设置周期性保存
- 新增`--load_model`参数，用于加载已保存模型并在测试集上评估
- 更新README，补充保存与加载用法示例

## Testing
- `python -m py_compile main.py model/model.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68bad8d503948325a5aaa439e9c20060