### PR TITLE
添加训练与测试脚本

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Evaluate the model on the test set using a pretrained checkpoint without training.
+# Usage: bash test.sh [path_to_checkpoint]
+
+MODEL_PATH=${1:-ckpt/best_model.pt}
+python main.py --encoder_v resnet101 --gate --load_model "$MODEL_PATH"

--- a/train.sh
+++ b/train.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Train the model with ResNet101 visual encoder and gating, saving checkpoints every epoch.
+
+python main.py --encoder_v resnet101 --gate --save_interval 1 "$@"


### PR DESCRIPTION
## Summary
- 新增 `train.sh`，封装训练命令。
- 新增 `test.sh`，加载已训练模型并在测试集上评估。

## Testing
- `bash train.sh` *(失败：ModuleNotFoundError: No module named 'numpy')*
- `bash test.sh` *(失败：ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68bae74c66848325af968bc07cf31da7