### PR TITLE
feat: 输出训练与测试结果

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -38,23 +38,32 @@ def train(loader, model, optimizer, task, weight=1.0):
     return np.mean(losses)
 
 
-def evaluate(model, loader):
+def evaluate(model, loader, return_preds: bool = False):
     true_labels = []
     pred_labels = []
+    tokens = []
 
     model.eval()
     with torch.no_grad():
         for batch in tqdm(loader):
             _, pred = model.ner_forward(batch)
             pairs = batch["pairs"] if isinstance(batch, dict) else batch
+            tokens += [[token.text for token in pair.sentence] for pair in pairs]
             true_labels += [[constants.ID_TO_LABEL[token.label] for token in pair.sentence] for pair in pairs]
             pred_labels += pred
 
     total = sum(len(seq) for seq in true_labels)
-    correct = sum(t == p for seq_t, seq_p in zip(true_labels, pred_labels) for t, p in zip(seq_t, seq_p))
+    correct = sum(
+        t == p
+        for seq_t, seq_p in zip(true_labels, pred_labels)
+        for t, p in zip(seq_t, seq_p)
+    )
     wrong = total - correct
 
     f1 = f1_score(true_labels, pred_labels, mode='strict', scheme=IOB2)
     report = classification_report(true_labels, pred_labels, digits=4, mode='strict', scheme=IOB2)
+
+    if return_preds:
+        return f1, report, total, correct, wrong, tokens, pred_labels, true_labels
 
     return f1, report, total, correct, wrong


### PR DESCRIPTION
## Summary
- 支持在评估函数中返回输入文本、预测标签与真实标签
- 新增保存结果的工具函数, 训练与测试时分别输出 groundtruth 和预测结果到 `result/`

## Testing
- `python -m py_compile main.py utils.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c172a35f5c832585d8ba90d5e2e749