### PR TITLE
feat: 输出预测文件路径

### DIFF
--- a/main.py
+++ b/main.py
@@ -81,6 +81,13 @@ def main():
                 {'tokens': t, 'labels': l}
                 for t, l in zip(tokens, preds)
             ], f, ensure_ascii=False, indent=4)
+        if mode == 'train':
+            print(f'训练集文件输出至{gt_path}目录下')
+        elif mode == 'test':
+            print(f'测试集文件输出至{gt_path}目录下')
+        else:
+            print(f'{mode}集文件输出至{gt_path}目录下')
+        print(f'模型预测文件输出至{res_path}目录下')
 
     if args.load_model:
         state = torch.load(args.load_model, map_location=model.device)


### PR DESCRIPTION
## Summary
- 在保存结果后打印训练或测试集文件及模型预测文件的输出路径

## Testing
- `python -m py_compile main.py && echo PY_COMPILE_SUCCESS`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68c1838cc28883259170540cb7850df5